### PR TITLE
UTCT-86: Change hook to make compatible with 404 plugin.

### DIFF
--- a/404.php
+++ b/404.php
@@ -7,7 +7,7 @@
         <div class="col-12 col-lg-10 col-xl-8 col-xxl-5 mt-5">
             <div class="card border-0 mt-5">
                     <div class="text-center">
-                        <img src="frontend/assets/svg/utc-wordmark-reverse.svg" alt="UTC Logo" width="300px" style="margin-top:-4rem;">
+                        <img src="<?php $_SERVER['DOCUMENT_ROOT'] ?>/frontend/assets/svg/utc-wordmark-reverse.svg" alt="UTC Logo" width="300px" style="margin-top:-4rem;">
                     </div>
                     <div class="card-body px-md-5">
                         <h1>Sorry,</h1>

--- a/user/plugins/seans-qrcode/plugin.php
+++ b/user/plugins/seans-qrcode/plugin.php
@@ -42,7 +42,7 @@ class LogoOptions extends QROptions{
 }
 
 // Kick in if the loader does not recognize a valid pattern
-yourls_add_action( 'loader_failed', 'sean_yourls_qrcode' );
+yourls_add_action( 'redirect_keyword_not_found', 'sean_yourls_qrcode' );
 function sean_yourls_qrcode( $request ) {
 	// Get authorized charset in keywords and make a regexp pattern
 	$pattern = yourls_make_regexp_pattern( yourls_get_shorturl_charset() );


### PR DESCRIPTION
Sean's QR code plugin was not working when firing on the loader_failed hook. Changing it to redirect_keyword_not_found ([suggested by ozh](https://github.com/YOURLS/404-if-not-found/issues/1)) fixes the problem.