### PR TITLE
UTCT-91: Update QR code generator.

### DIFF
--- a/user/plugins/seans-qrcode/composer.lock
+++ b/user/plugins/seans-qrcode/composer.lock
@@ -89,16 +89,16 @@
         },
         {
             "name": "chillerlan/php-settings-container",
-            "version": "3.1.1",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/chillerlan/php-settings-container.git",
-                "reference": "c41e89f8bf963d1e88584a47fb78d1cd204b6e2a"
+                "reference": "8f93648fac8e6bacac8e00a8d325eba4950295e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chillerlan/php-settings-container/zipball/c41e89f8bf963d1e88584a47fb78d1cd204b6e2a",
-                "reference": "c41e89f8bf963d1e88584a47fb78d1cd204b6e2a",
+                "url": "https://api.github.com/repos/chillerlan/php-settings-container/zipball/8f93648fac8e6bacac8e00a8d325eba4950295e6",
+                "reference": "8f93648fac8e6bacac8e00a8d325eba4950295e6",
                 "shasum": ""
             },
             "require": {
@@ -107,9 +107,9 @@
             },
             "require-dev": {
                 "phan/phan": "^5.4",
-                "phpcsstandards/php_codesniffer": "^3.8",
                 "phpmd/phpmd": "^2.15",
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^10.5",
+                "squizlabs/php_codesniffer": "^3.9"
             },
             "type": "library",
             "autoload": {
@@ -150,7 +150,7 @@
                     "type": "ko_fi"
                 }
             ],
-            "time": "2024-01-05T23:55:20+00:00"
+            "time": "2024-03-02T20:07:15+00:00"
         }
     ],
     "packages-dev": [],


### PR DESCRIPTION
Signed-off-by: Chris Gilligan <49878588+UTCGilligan@users.noreply.github.com>

Works well in https://gotest.utc.edu with test release 1.5.2
- https://github.com/UTCGilligan/utctiny/releases/tag/1.5.2

Package operations: 0 installs, 1 update, 0 removals
  - Upgrading chillerlan/php-settings-container (3.1.1 => 3.2.0)

Also need to run composer install in the hosted environments.
- [x] gotest.utc.edu
- [ ] go.utc.edu