### PR TITLE
Update Bootstrap and Popper frontend versions

### DIFF
--- a/frontend/footer.php
+++ b/frontend/footer.php
@@ -1,5 +1,5 @@
-<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.6/dist/umd/popper.min.js" integrity="sha384-oBqDVmMz9ATKxIep9tiCxS/Z9fNfEXiDAYTujMAeBAsjFuCZSmKbSSUnQlmh/jp3" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.min.js" integrity="sha384-cuYeSxntonz0PPNlHhBs68uyIAVpIIOZZ5JqeqvYYIcEL727kskC66kF92t6Xl2V" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js" integrity="sha384-I7E8VVD/ismYTF4hNIPjVp/Zjvgyol6VFvRkX/vR+Vc4jQkC+hVqc2pM8ODewa9r" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.min.js" integrity="sha384-0pUGZvbkm6XF6gxjEnlmuGrJXVbNuzT9qBBavbLwCsOGabYfZo0T0to5eqruptLy" crossorigin="anonymous"></script>
 <script>
 	// From https://stackoverflow.com/a/30810322
 	function fallbackCopyTextToClipboard(text) {


### PR DESCRIPTION
- Bootstrap 5.3.3
- Popper 2.11.8

Tested and working in local:
<img width="1904" alt="Screenshot 2025-03-12 at 11 29 27" src="https://github.com/user-attachments/assets/66e892d2-d387-472f-8e82-48c277f586f2" />
